### PR TITLE
Update README.md to emphasize online HTML version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ Port of the book Think Python to the Julia programming language
 
 [![Build Status](https://travis-ci.org/BenLauwens/ThinkJulia.jl.svg?branch=master)](https://travis-ci.org/BenLauwens/ThinkJulia.jl)
 
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://benlauwens.github.io/ThinkJulia.jl/latest/book.html)
+# Read the HTML version of the book online:
+Click here: [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://benlauwens.github.io/ThinkJulia.jl/latest/book.html)


### PR DESCRIPTION
Hello,

I didn't realize that the `docs` "icon" leads to the online HTML version of the book and kept using a search engine to get there. So maybe it would be helpful to emphasize that feature?