### PR TITLE
Correct `rightjustify`

### DIFF
--- a/src/solutions/chap03.jl
+++ b/src/solutions/chap03.jl
@@ -1,6 +1,6 @@
 function rightjustify(s)
   n = 70 - length(s)
-  println(" "^70 * s)
+  println(" "^n * s)
 end
 
 function dotwice(f)


### PR DESCRIPTION
In the exercise, it says that the last letter of the string should be in column 70 of the display. Instead, the first letter is in column 71.