### PR TITLE
Change `add ThinkJulia` to use full URL

### DIFF
--- a/book/src/chap04.asciidoc
+++ b/book/src/chap04.asciidoc
@@ -17,7 +17,7 @@ Packages can be installed in the REPL by entering the Pkg REPL-mode using the ke
 
 [source,jlcon]
 ----
-(v0.7) pkg> add ThinkJulia
+(v0.7) pkg> add https://github.com/BenLauwens/ThinkJulia.jl
 ----
 
 This can take some time.


### PR DESCRIPTION
`add ThinkJulia` doesn't work in Julia 1.0. However, `add https://github.com/BenLauwens/ThinkJulia.jl` does work.

Fixes #10.