### PR TITLE
`vcat ` works for both arrays and elements in 1.x

### DIFF
--- a/book/src/chap10.asciidoc
+++ b/book/src/chap10.asciidoc
@@ -780,7 +780,6 @@ And these are wrong:
 ----
 insert!(t, 4, [x])         # WRONG!
 push!(t, [x])              # WRONG!
-vcat(t, [x])               # WRONG!
 ----
 
 * Make copies to avoid aliasing.


### PR DESCRIPTION
I suspect that you intended to say
```julia
vcat(t, x)               # WRONG!
```
instead of
```julia
vcat(t, [x])             # WRONG!
```

However, in `1.x` both are correct.